### PR TITLE
Update AppCenter/Core to 4.3.0

### DIFF
--- a/AppCenterCapacitorShared.podspec
+++ b/AppCenterCapacitorShared.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '12.0'
   s.swift_version = '5.1'
   s.source_files = '*.swift'
-  s.dependency 'AppCenter/Core', '4.2.0'
+  s.dependency 'AppCenter/Core', '4.3.0'
   s.static_framework = true
   # s.vendored_frameworks = '**/AppCenterCapacitorShared.xcframework'
 end

--- a/AppCenterCapacitorShared.podspec
+++ b/AppCenterCapacitorShared.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppCenterCapacitorShared'
-  s.version          = '0.3.1'
+  s.version          = '0.3.2'
   s.summary          = 'Shared utility to assist with bootstrapping AppCenter for Capacitor plugin.'
   s.homepage         = 'https://github.com/capacitor-community/appcenter-sdk-capacitor'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/AppCenterCapacitorShared.swift
+++ b/AppCenterCapacitorShared.swift
@@ -31,7 +31,7 @@ public class AppCenterCapacitorShared: NSObject {
             return
         }
         
-        let wrapperSdk = WrapperSdk(wrapperSdkVersion: "0.3.1", wrapperSdkName: "appcenter.capacitor", wrapperRuntimeVersion: nil, liveUpdateReleaseLabel: nil, liveUpdateDeploymentKey: nil, liveUpdatePackageHash: nil)
+        let wrapperSdk = WrapperSdk(wrapperSdkVersion: "0.3.2", wrapperSdkName: "appcenter.capacitor", wrapperRuntimeVersion: nil, liveUpdateReleaseLabel: nil, liveUpdateDeploymentKey: nil, liveUpdatePackageHash: nil)
 
         setWrapperSdk(wrapperSdk!)
         getSdkConfig()

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AppCenter/Core (4.2.0)
-  - AppCenterCapacitorShared (0.3.1):
-    - AppCenter/Core (= 4.2.0)
+  - AppCenter/Core (4.3.0)
+  - AppCenterCapacitorShared (0.3.2):
+    - AppCenter/Core (= 4.3.0)
 
 DEPENDENCIES:
   - AppCenterCapacitorShared (from `../`)
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  AppCenter: 87ef6eefd8ade4df59e88951288587429f3dd2a5
-  AppCenterCapacitorShared: 7514580229eb653607bef4a699699ca854a271f7
+  AppCenter: 883369ab78427b0561c688158d689dfe1f993ea9
+  AppCenterCapacitorShared: 3643108692ca6d59904fa45edd3b2631c32b1532
 
 PODFILE CHECKSUM: fe3b1998cfd9db5f6be13fa9f965c722197a749c
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/Example/Pods/Local Podspecs/AppCenterCapacitorShared.podspec.json
+++ b/Example/Pods/Local Podspecs/AppCenterCapacitorShared.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "AppCenterCapacitorShared",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "summary": "Shared utility to assist with bootstrapping AppCenter for Capacitor plugin.",
   "homepage": "https://github.com/capacitor-community/appcenter-sdk-capacitor",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/johnborges/AppCenterCapacitorShared.git",
-    "tag": "0.3.1"
+    "tag": "0.3.2"
   },
   "social_media_url": "https://twitter.com/johnborges",
   "platforms": {
@@ -22,7 +22,7 @@
   "source_files": "*.swift",
   "dependencies": {
     "AppCenter/Core": [
-      "4.2.0"
+      "4.3.0"
     ]
   },
   "static_framework": true,

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,7 +1,7 @@
 PODS:
-  - AppCenter/Core (4.2.0)
-  - AppCenterCapacitorShared (0.3.1):
-    - AppCenter/Core (= 4.2.0)
+  - AppCenter/Core (4.3.0)
+  - AppCenterCapacitorShared (0.3.2):
+    - AppCenter/Core (= 4.3.0)
 
 DEPENDENCIES:
   - AppCenterCapacitorShared (from `../`)
@@ -15,9 +15,9 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  AppCenter: 87ef6eefd8ade4df59e88951288587429f3dd2a5
-  AppCenterCapacitorShared: 7514580229eb653607bef4a699699ca854a271f7
+  AppCenter: 883369ab78427b0561c688158d689dfe1f993ea9
+  AppCenterCapacitorShared: 3643108692ca6d59904fa45edd3b2631c32b1532
 
 PODFILE CHECKSUM: fe3b1998cfd9db5f6be13fa9f965c722197a749c
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2


### PR DESCRIPTION
Hey John, I saw that there's a new version of AppCenter/Core and AppCenter/Crashes of 4.3.0 which adds the `Crashes.trackError` and `Crashes.trackException` methods https://github.com/microsoft/appcenter-sdk-apple/releases/tag/4.3.0.

I tried to install AppCenter/Crashes v4.3.0 in the `appcenter-sdk-capacitor/appcenter-crashes` plugin podfile
![image](https://user-images.githubusercontent.com/5609118/134395039-0f2da8df-4a93-42eb-af48-70b4aaa61914.png)

but I couldn't install it since it's conflicting with AppCenterCapacitorShared's podspec

![image](https://user-images.githubusercontent.com/5609118/134394813-b9d2d141-cd9e-48dc-a3fb-a0d56fcc19ce.png)


In my pull request to `@capacitor-community/appcenter-crashes` https://github.com/capacitor-community/appcenter-sdk-capacitor/pull/31 where I added the `Crashes.trackError` method, I mentioned that for iOS, the method wasn't supported in the AppCenter Crashes SDK. Now it seems they've added it, so I'm hoping that we can update it.